### PR TITLE
Unlist and format manifests

### DIFF
--- a/manifests/clab/0009_edge-interfaces.yaml
+++ b/manifests/clab/0009_edge-interfaces.yaml
@@ -1,165 +1,167 @@
-apiVersion: v1
-items:
-  - apiVersion: interfaces.eda.nokia.com/v1alpha1
-    kind: Interface
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf201: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: lag-l1-l2-eth-1-1-lag-1-local
-      namespace: clab-eda-st
-    spec:
-      enabled: true
-      encapType: dot1q
-      ethernet:
-        reloadDelayTimer: 60
-        speed: 10G
-        stormControl: {}
-      lag:
-        lacp:
-          interval: fast
-          mode: active
-          systemPriority: 32768
-        minLinks: 1
-        multihoming:
-          esi: auto
-          mode: all-active
-          reloadDelayTimer: 60
-          revertive: false
-        type: lacp
-      lldp: true
-      members:
-        - enabled: true
-          interface: ethernet-1-1
-          lacpPortPriority: 32768
-          node: leaf1
-        - enabled: true
-          interface: ethernet-1-1
-          lacpPortPriority: 32768
-          node: leaf2
-      type: lag
-  - apiVersion: interfaces.eda.nokia.com/v1alpha1
-    kind: Interface
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf202: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: lag-l1-l2-eth-1-2-lag-2-local
-      namespace: clab-eda-st
-    spec:
-      enabled: true
-      encapType: dot1q
-      ethernet:
-        reloadDelayTimer: 60
-        speed: 10G
-        stormControl: {}
-      lag:
-        lacp:
-          interval: fast
-          mode: active
-          systemPriority: 32768
-        minLinks: 1
-        multihoming:
-          esi: auto
-          mode: all-active
-          reloadDelayTimer: 60
-          revertive: false
-        type: lacp
-      lldp: true
-      members:
-        - enabled: true
-          interface: ethernet-1-2
-          lacpPortPriority: 32768
-          node: leaf1
-        - enabled: true
-          interface: ethernet-1-2
-          lacpPortPriority: 32768
-          node: leaf2
-      type: lag
-  - apiVersion: interfaces.eda.nokia.com/v1alpha1
-    kind: Interface
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf201: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: lag-l3-l4-eth-1-1-lag-3-local
-      namespace: clab-eda-st
-    spec:
-      enabled: true
-      encapType: dot1q
-      ethernet:
-        reloadDelayTimer: 60
-        speed: 10G
-        stormControl: {}
-      lag:
-        lacp:
-          interval: fast
-          mode: active
-          systemPriority: 32768
-        minLinks: 1
-        multihoming:
-          esi: auto
-          mode: all-active
-          reloadDelayTimer: 60
-          revertive: false
-        type: lacp
-      lldp: true
-      members:
-        - enabled: true
-          interface: ethernet-1-1
-          lacpPortPriority: 32768
-          node: leaf3
-        - enabled: true
-          interface: ethernet-1-1
-          lacpPortPriority: 32768
-          node: leaf4
-      type: lag
-  - apiVersion: interfaces.eda.nokia.com/v1alpha1
-    kind: Interface
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf202: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: lag-l3-l4-eth-1-2-lag-4-local
-      namespace: clab-eda-st
-    spec:
-      enabled: true
-      encapType: dot1q
-      ethernet:
-        reloadDelayTimer: 60
-        speed: 10G
-        stormControl: {}
-      lag:
-        lacp:
-          interval: fast
-          mode: active
-          systemPriority: 32768
-        minLinks: 1
-        multihoming:
-          esi: auto
-          mode: all-active
-          reloadDelayTimer: 60
-          revertive: false
-        type: lacp
-      lldp: true
-      members:
-        - enabled: true
-          interface: ethernet-1-2
-          lacpPortPriority: 32768
-          node: leaf3
-        - enabled: true
-          interface: ethernet-1-2
-          lacpPortPriority: 32768
-          node: leaf4
-      type: lag
-kind: List
+---
+apiVersion: interfaces.eda.nokia.com/v1alpha1
+kind: Interface
 metadata:
-  resourceVersion: ''
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf201: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: lag-l1-l2-eth-1-1-lag-1-local
+  namespace: clab-eda-st
+spec:
+  enabled: true
+  encapType: dot1q
+  ethernet:
+    reloadDelayTimer: 60
+    speed: 10G
+    stormControl: {}
+  lag:
+    lacp:
+      interval: fast
+      mode: active
+      systemPriority: 32768
+    minLinks: 1
+    multihoming:
+      esi: auto
+      mode: all-active
+      reloadDelayTimer: 60
+      revertive: false
+    type: lacp
+  lldp: true
+  members:
+    - enabled: true
+      interface: ethernet-1-1
+      lacpPortPriority: 32768
+      node: leaf1
+    - enabled: true
+      interface: ethernet-1-1
+      lacpPortPriority: 32768
+      node: leaf2
+  type: lag
+
+---
+apiVersion: interfaces.eda.nokia.com/v1alpha1
+kind: Interface
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf202: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: lag-l1-l2-eth-1-2-lag-2-local
+  namespace: clab-eda-st
+spec:
+  enabled: true
+  encapType: dot1q
+  ethernet:
+    reloadDelayTimer: 60
+    speed: 10G
+    stormControl: {}
+  lag:
+    lacp:
+      interval: fast
+      mode: active
+      systemPriority: 32768
+    minLinks: 1
+    multihoming:
+      esi: auto
+      mode: all-active
+      reloadDelayTimer: 60
+      revertive: false
+    type: lacp
+  lldp: true
+  members:
+    - enabled: true
+      interface: ethernet-1-2
+      lacpPortPriority: 32768
+      node: leaf1
+    - enabled: true
+      interface: ethernet-1-2
+      lacpPortPriority: 32768
+      node: leaf2
+  type: lag
+
+---
+apiVersion: interfaces.eda.nokia.com/v1alpha1
+kind: Interface
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf201: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: lag-l3-l4-eth-1-1-lag-3-local
+  namespace: clab-eda-st
+spec:
+  enabled: true
+  encapType: dot1q
+  ethernet:
+    reloadDelayTimer: 60
+    speed: 10G
+    stormControl: {}
+  lag:
+    lacp:
+      interval: fast
+      mode: active
+      systemPriority: 32768
+    minLinks: 1
+    multihoming:
+      esi: auto
+      mode: all-active
+      reloadDelayTimer: 60
+      revertive: false
+    type: lacp
+  lldp: true
+  members:
+    - enabled: true
+      interface: ethernet-1-1
+      lacpPortPriority: 32768
+      node: leaf3
+    - enabled: true
+      interface: ethernet-1-1
+      lacpPortPriority: 32768
+      node: leaf4
+  type: lag
+
+---
+apiVersion: interfaces.eda.nokia.com/v1alpha1
+kind: Interface
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf202: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: lag-l3-l4-eth-1-2-lag-4-local
+  namespace: clab-eda-st
+spec:
+  enabled: true
+  encapType: dot1q
+  ethernet:
+    reloadDelayTimer: 60
+    speed: 10G
+    stormControl: {}
+  lag:
+    lacp:
+      interval: fast
+      mode: active
+      systemPriority: 32768
+    minLinks: 1
+    multihoming:
+      esi: auto
+      mode: all-active
+      reloadDelayTimer: 60
+      revertive: false
+    type: lacp
+  lldp: true
+  members:
+    - enabled: true
+      interface: ethernet-1-2
+      lacpPortPriority: 32768
+      node: leaf3
+    - enabled: true
+      interface: ethernet-1-2
+      lacpPortPriority: 32768
+      node: leaf4
+  type: lag

--- a/manifests/clab/0010_topolinks.yaml
+++ b/manifests/clab/0010_topolinks.yaml
@@ -1,101 +1,103 @@
-apiVersion: v1
-items:
-  - apiVersion: core.eda.nokia.com/v1
-    kind: TopoLink
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf201: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: l1-l2-eth-1-1-lag-1
-      namespace: clab-eda-st
-    spec:
-      links:
-        - local:
-            interface: ethernet-1-1
-            interfaceResource: leaf1-ethernet-1-1
-            node: leaf1
-          speed: 10G
-          type: edge
-        - local:
-            interface: ethernet-1-1
-            interfaceResource: leaf2-ethernet-1-1
-            node: leaf2
-          speed: 10G
-          type: edge
-  - apiVersion: core.eda.nokia.com/v1
-    kind: TopoLink
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf202: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: l1-l2-eth-1-2-lag-2
-      namespace: clab-eda-st
-    spec:
-      links:
-        - local:
-            interface: ethernet-1-2
-            interfaceResource: leaf1-ethernet-1-2
-            node: leaf1
-          speed: 10G
-          type: edge
-        - local:
-            interface: ethernet-1-2
-            interfaceResource: leaf2-ethernet-1-2
-            node: leaf2
-          speed: 10G
-          type: edge
-  - apiVersion: core.eda.nokia.com/v1
-    kind: TopoLink
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf201: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: l3-l4-eth-1-1-lag-3
-      namespace: clab-eda-st
-    spec:
-      links:
-        - local:
-            interface: ethernet-1-1
-            interfaceResource: leaf3-ethernet-1-1
-            node: leaf3
-          speed: 10G
-          type: edge
-        - local:
-            interface: ethernet-1-1
-            interfaceResource: leaf4-ethernet-1-1
-            node: leaf4
-          speed: 10G
-          type: edge
-  - apiVersion: core.eda.nokia.com/v1
-    kind: TopoLink
-    metadata:
-      generation: 1
-      labels:
-        eda.nokia.com/macvrf202: 'true'
-        eda.nokia.com/macvrf1001: 'true'
-        eda.nokia.com/role: edge
-      name: l3-l4-eth-1-2-lag-4
-      namespace: clab-eda-st
-    spec:
-      links:
-        - local:
-            interface: ethernet-1-2
-            interfaceResource: leaf3-ethernet-1-2
-            node: leaf3
-          speed: 10G
-          type: edge
-        - local:
-            interface: ethernet-1-2
-            interfaceResource: leaf4-ethernet-1-2
-            node: leaf4
-          speed: 10G
-          type: edge
-kind: List
+---
+apiVersion: core.eda.nokia.com/v1
+kind: TopoLink
 metadata:
-  resourceVersion: ''
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf201: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: l1-l2-eth-1-1-lag-1
+  namespace: clab-eda-st
+spec:
+  links:
+    - local:
+        interface: ethernet-1-1
+        interfaceResource: leaf1-ethernet-1-1
+        node: leaf1
+      speed: 10G
+      type: edge
+    - local:
+        interface: ethernet-1-1
+        interfaceResource: leaf2-ethernet-1-1
+        node: leaf2
+      speed: 10G
+      type: edge
+
+---
+apiVersion: core.eda.nokia.com/v1
+kind: TopoLink
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf202: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: l1-l2-eth-1-2-lag-2
+  namespace: clab-eda-st
+spec:
+  links:
+    - local:
+        interface: ethernet-1-2
+        interfaceResource: leaf1-ethernet-1-2
+        node: leaf1
+      speed: 10G
+      type: edge
+    - local:
+        interface: ethernet-1-2
+        interfaceResource: leaf2-ethernet-1-2
+        node: leaf2
+      speed: 10G
+      type: edge
+
+---
+apiVersion: core.eda.nokia.com/v1
+kind: TopoLink
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf201: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: l3-l4-eth-1-1-lag-3
+  namespace: clab-eda-st
+spec:
+  links:
+    - local:
+        interface: ethernet-1-1
+        interfaceResource: leaf3-ethernet-1-1
+        node: leaf3
+      speed: 10G
+      type: edge
+    - local:
+        interface: ethernet-1-1
+        interfaceResource: leaf4-ethernet-1-1
+        node: leaf4
+      speed: 10G
+      type: edge
+
+---
+apiVersion: core.eda.nokia.com/v1
+kind: TopoLink
+metadata:
+  generation: 1
+  labels:
+    eda.nokia.com/macvrf202: "true"
+    eda.nokia.com/macvrf1001: "true"
+    eda.nokia.com/role: edge
+  name: l3-l4-eth-1-2-lag-4
+  namespace: clab-eda-st
+spec:
+  links:
+    - local:
+        interface: ethernet-1-2
+        interfaceResource: leaf3-ethernet-1-2
+        node: leaf3
+      speed: 10G
+      type: edge
+    - local:
+        interface: ethernet-1-2
+        interfaceResource: leaf4-ethernet-1-2
+        node: leaf4
+      speed: 10G
+      type: edge

--- a/manifests/clab/0020_exporters.yaml
+++ b/manifests/clab/0020_exporters.yaml
@@ -88,9 +88,9 @@ metadata:
 spec:
   exports:
     - mappings:
-        - destination: '1'
+        - destination: "1"
           source: up
-        - destination: '0'
+        - destination: "0"
           source: down
       metricName:
         regex: namespace_(.+)
@@ -140,9 +140,9 @@ metadata:
 spec:
   exports:
     - mappings:
-        - destination: '1'
+        - destination: "1"
           source: up
-        - destination: '0'
+        - destination: "0"
           source: down
       metricName:
         regex: namespace_(.+)

--- a/manifests/clab/0021_syslog.yaml
+++ b/manifests/clab/0021_syslog.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: clab-eda-st
 spec:
   configs:
-  - config: |-
-      {
+    - config: |-
+        {
           "logging": {
               "network-instance": "mgmt",
               "remote-server": [
@@ -25,11 +25,11 @@ spec:
                   }
               ]
           }
-      }
-    operation: Update
-    path: .system
+        }
+      operation: Update
+      path: .system
   endpointSelector:
-  - eda.nokia.com/role=leaf
-  - eda.nokia.com/role=spine
+    - eda.nokia.com/role=leaf
+    - eda.nokia.com/role=spine
   operatingSystem: srl
   priority: 0

--- a/manifests/clab/0030_fabric.yaml
+++ b/manifests/clab/0030_fabric.yaml
@@ -1,58 +1,53 @@
-apiVersion: v1
-items:
-- apiVersion: fabrics.eda.nokia.com/v1alpha1
-  kind: Fabric
-  metadata:
-    name: fabric
-    namespace: clab-eda-st
-  spec:
-    interSwitchLinks:
-      linkSelector:
-      - eda.nokia.com/role=interSwitch
-      poolIPV4: ipv4-pool
-    leafs:
-      leafNodeSelector:
-      - eda.nokia.com/role=leaf
-    overlayProtocol:
-      bfd:
-        desiredMinTransmitInt: 1000000
-        detectionMultiplier: 3
-        enabled: true
-        minEchoReceiveInterval: 1000000
-        requiredMinReceive: 1000000
-      bgp:
-        autonomousSystem: 65100
-        clusterID: "100"
-        rrClientNodeSelector:
-        - eda.nokia.com/role=leaf
-        rrNodeSelector:
-        - eda.nokia.com/role=spine
-        timers:
-          connectRetry: 10
-          holdTime: 3
-          keepAlive: 1
-          minimumAdvertisementInterval: 1
-      protocol: IBGP
-    spines:
-      spineNodeSelector:
-      - eda.nokia.com/role=spine
-    systemPoolIPV4: systemipv4-pool
-    underlayProtocol:
-      bfd:
-        desiredMinTransmitInt: 100000
-        detectionMultiplier: 3
-        enabled: true
-        minEchoReceiveInterval: 1000000
-        requiredMinReceive: 100000
-      bgp:
-        asnPool: asn-pool
-        timers:
-          connectRetry: 10
-          holdTime: 3
-          keepAlive: 1
-          minimumAdvertisementInterval: 1
-      protocol:
-      - EBGP
-kind: List
+apiVersion: fabrics.eda.nokia.com/v1alpha1
+kind: Fabric
 metadata:
-  resourceVersion: ""
+  name: fabric
+  namespace: clab-eda-st
+spec:
+  interSwitchLinks:
+    linkSelector:
+      - eda.nokia.com/role=interSwitch
+    poolIPV4: ipv4-pool
+  leafs:
+    leafNodeSelector:
+      - eda.nokia.com/role=leaf
+  overlayProtocol:
+    bfd:
+      desiredMinTransmitInt: 1000000
+      detectionMultiplier: 3
+      enabled: true
+      minEchoReceiveInterval: 1000000
+      requiredMinReceive: 1000000
+    bgp:
+      autonomousSystem: 65100
+      clusterID: "100"
+      rrClientNodeSelector:
+        - eda.nokia.com/role=leaf
+      rrNodeSelector:
+        - eda.nokia.com/role=spine
+      timers:
+        connectRetry: 10
+        holdTime: 3
+        keepAlive: 1
+        minimumAdvertisementInterval: 1
+    protocol: IBGP
+  spines:
+    spineNodeSelector:
+      - eda.nokia.com/role=spine
+  systemPoolIPV4: systemipv4-pool
+  underlayProtocol:
+    bfd:
+      desiredMinTransmitInt: 100000
+      detectionMultiplier: 3
+      enabled: true
+      minEchoReceiveInterval: 1000000
+      requiredMinReceive: 100000
+    bgp:
+      asnPool: asn-pool
+      timers:
+        connectRetry: 10
+        holdTime: 3
+        keepAlive: 1
+        minimumAdvertisementInterval: 1
+    protocol:
+      - EBGP

--- a/manifests/clab/0040_ipvrf2001.yaml
+++ b/manifests/clab/0040_ipvrf2001.yaml
@@ -5,111 +5,111 @@ metadata:
   namespace: clab-eda-st
 spec:
   bridgeDomains:
-  - name: macvrf201
-    spec:
-      eviPool: evi-pool
-      l2proxyARPND:
-        proxyARP: false
-        proxyND: false
-        tableSize: 250
-      macAging: 300
-      macDuplicationDetection:
-        action: StopLearning
-        enabled: true
-        holdDownTime: 9
-        monitoringWindow: 3
-        numMoves: 5
-      tunnelIndexPool: tunnel-index-pool
-      vniPool: vni-pool
-      macLimit: 250
-  - name: macvrf202
-    spec:
-      eviPool: evi-pool
-      l2proxyARPND:
-        proxyARP: false
-        proxyND: false
-        tableSize: 250
-      macAging: 300
-      macDuplicationDetection:
-        action: StopLearning
-        enabled: true
-        holdDownTime: 9
-        monitoringWindow: 3
-        numMoves: 5
-      tunnelIndexPool: tunnel-index-pool
-      vniPool: vni-pool
-      macLimit: 250
+    - name: macvrf201
+      spec:
+        eviPool: evi-pool
+        l2proxyARPND:
+          proxyARP: false
+          proxyND: false
+          tableSize: 250
+        macAging: 300
+        macDuplicationDetection:
+          action: StopLearning
+          enabled: true
+          holdDownTime: 9
+          monitoringWindow: 3
+          numMoves: 5
+        tunnelIndexPool: tunnel-index-pool
+        vniPool: vni-pool
+        macLimit: 250
+    - name: macvrf202
+      spec:
+        eviPool: evi-pool
+        l2proxyARPND:
+          proxyARP: false
+          proxyND: false
+          tableSize: 250
+        macAging: 300
+        macDuplicationDetection:
+          action: StopLearning
+          enabled: true
+          holdDownTime: 9
+          monitoringWindow: 3
+          numMoves: 5
+        tunnelIndexPool: tunnel-index-pool
+        vniPool: vni-pool
+        macLimit: 250
   irbInterfaces:
-  - name: macvrf201-irb
-    spec:
-      arpTimeout: 14400
-      bridgeDomain: macvrf201
-      evpnRouteAdvertisementType:
-        arpDynamic: true
-        arpStatic: false
-        ndDynamic: false
-        ndStatic: false
-      hostRoutePopulate:
-        dynamic: true
-        evpn: false
-        static: false
-      ipMTU: 1500
-      ipAddresses:
-      - ipv4Address:
-          ipPrefix: 10.20.1.254/24
-          primary: false
-      l3ProxyARPND:
-        proxyARP: false
-        proxyND: false
-      learnUnsolicited: NONE
-      router: ipvrf2001
-  - name: macvrf202-irb
-    spec:
-      arpTimeout: 14400
-      bridgeDomain: macvrf202
-      evpnRouteAdvertisementType:
-        arpDynamic: true
-        arpStatic: false
-        ndDynamic: false
-        ndStatic: false
-      hostRoutePopulate:
-        dynamic: true
-        evpn: false
-        static: false
-      ipMTU: 1500
-      ipAddresses:
-      - ipv4Address:
-          ipPrefix: 10.20.2.254/24
-          primary: false
-      l3ProxyARPND:
-        proxyARP: false
-        proxyND: false
-      learnUnsolicited: NONE
-      router: ipvrf2001
+    - name: macvrf201-irb
+      spec:
+        arpTimeout: 14400
+        bridgeDomain: macvrf201
+        evpnRouteAdvertisementType:
+          arpDynamic: true
+          arpStatic: false
+          ndDynamic: false
+          ndStatic: false
+        hostRoutePopulate:
+          dynamic: true
+          evpn: false
+          static: false
+        ipMTU: 1500
+        ipAddresses:
+          - ipv4Address:
+              ipPrefix: 10.20.1.254/24
+              primary: false
+        l3ProxyARPND:
+          proxyARP: false
+          proxyND: false
+        learnUnsolicited: NONE
+        router: ipvrf2001
+    - name: macvrf202-irb
+      spec:
+        arpTimeout: 14400
+        bridgeDomain: macvrf202
+        evpnRouteAdvertisementType:
+          arpDynamic: true
+          arpStatic: false
+          ndDynamic: false
+          ndStatic: false
+        hostRoutePopulate:
+          dynamic: true
+          evpn: false
+          static: false
+        ipMTU: 1500
+        ipAddresses:
+          - ipv4Address:
+              ipPrefix: 10.20.2.254/24
+              primary: false
+        l3ProxyARPND:
+          proxyARP: false
+          proxyND: false
+        learnUnsolicited: NONE
+        router: ipvrf2001
   routers:
-  - name: ipvrf2001
-    spec:
-      bgp:
-        ebgpPreference: 170
-        enabled: false
-        ibgpPreference: 170
-        minWaitToAdvertise: 0
-        rapidWithdrawl: true
-        waitForFIBInstall: false
-      eviPool: evi-pool
-      routerID: "2001"
-      tunnelIndexPool: tunnel-index-pool
-      vniPool: vni-pool
+    - name: ipvrf2001
+      spec:
+        bgp:
+          ebgpPreference: 170
+          enabled: false
+          ibgpPreference: 170
+          minWaitToAdvertise: 0
+          rapidWithdrawl: true
+          waitForFIBInstall: false
+        eviPool: evi-pool
+        routerID: "2001"
+        tunnelIndexPool: tunnel-index-pool
+        vniPool: vni-pool
   vlans:
-  - name: macvrf201
-    spec:
-      bridgeDomain: macvrf201
-      interfaceSelector:
-      - eda.nokia.com/macvrf201
-      vlanID: "201"
-  - name: macvrf202
-    spec:
-      bridgeDomain: macvrf202
-      interfaceSelector:
-      - eda.nokia.com/macvrf202
-      vlanID: "202"
+    - name: macvrf201
+      spec:
+        bridgeDomain: macvrf201
+        interfaceSelector:
+          - eda.nokia.com/macvrf201
+        vlanID: "201"
+    - name: macvrf202
+      spec:
+        bridgeDomain: macvrf202
+        interfaceSelector:
+          - eda.nokia.com/macvrf202
+        vlanID: "202"

--- a/manifests/clab/0041_macvrf1001.yaml
+++ b/manifests/clab/0041_macvrf1001.yaml
@@ -5,26 +5,26 @@ metadata:
   namespace: clab-eda-st
 spec:
   bridgeDomains:
-  - name: macvrf1001
-    spec:
-      eviPool: evi-pool
-      l2proxyARPND:
-        proxyARP: false
-        proxyND: false
-      macAging: 300
-      macDuplicationDetection:
-        action: StopLearning
-        enabled: true
-        holdDownTime: 9
-        monitoringWindow: 3
-        numMoves: 5
-      tunnelIndexPool: tunnel-index-pool
-      vniPool: vni-pool
-      macLimit: 250
+    - name: macvrf1001
+      spec:
+        eviPool: evi-pool
+        l2proxyARPND:
+          proxyARP: false
+          proxyND: false
+        macAging: 300
+        macDuplicationDetection:
+          action: StopLearning
+          enabled: true
+          holdDownTime: 9
+          monitoringWindow: 3
+          numMoves: 5
+        tunnelIndexPool: tunnel-index-pool
+        vniPool: vni-pool
+        macLimit: 250
   vlans:
-  - name: macvrf1001
-    spec:
-      bridgeDomain: macvrf1001
-      interfaceSelector:
-      - eda.nokia.com/macvrf1001
-      vlanID: "1001"
+    - name: macvrf1001
+      spec:
+        bridgeDomain: macvrf1001
+        interfaceSelector:
+          - eda.nokia.com/macvrf1001
+        vlanID: "1001"


### PR DESCRIPTION
`kind: List` is a weird kubectl construct. It likely adds more confusion than making it easier to author lists of resources, so I squashed it and used multi document yaml instead
