### PR TITLE
Add proxy env var to grafana node

### DIFF
--- a/eda-st.clab.yaml
+++ b/eda-st.clab.yaml
@@ -112,6 +112,10 @@ topology:
       ports:
         - 3000:3000
       env:
+        http_proxy: ${http_proxy:=""}
+        https_proxy: ${https_proxy:=""}
+        HTTP_PROXY: ${HTTP_PROXY:=""}
+        HTTPS_PROXY: ${HTTPS_PROXY:=""}
         GF_INSTALL_PLUGINS: "andrewbmchugh-flow-panel, volkovlabs-variable-panel"
         GF_ORG_ROLE: "Admin"
         GF_ORG_NAME: "Main Org"

--- a/eda-st.clab.yaml
+++ b/eda-st.clab.yaml
@@ -112,10 +112,7 @@ topology:
       ports:
         - 3000:3000
       env:
-        http_proxy: ${http_proxy:=""}
         https_proxy: ${https_proxy:=""}
-        HTTP_PROXY: ${HTTP_PROXY:=""}
-        HTTPS_PROXY: ${HTTPS_PROXY:=""}
         GF_INSTALL_PLUGINS: "andrewbmchugh-flow-panel, volkovlabs-variable-panel"
         GF_ORG_ROLE: "Admin"
         GF_ORG_NAME: "Main Org"


### PR DESCRIPTION
Since the grafana node is downloading plugins, some environments might need proxy settings. Adding this should work in both cases with and without proxy.