### PR TITLE
Add proxy support and update prometheus storage

### DIFF
--- a/charts/telemetry-stack/templates/deployment.yaml
+++ b/charts/telemetry-stack/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - --config.file=/etc/prometheus/prometheus.yml
             - --storage.tsdb.path=/prometheus
             - --storage.tsdb.retention.time=7d
+            - --storage.tsdb.retention.size=2GB
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus
@@ -81,6 +82,14 @@ spec:
           image: grafana/grafana:12.0.2
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
+            {{- if .Values.proxy.https }}
+            - name: HTTPS_PROXY
+              value: "{{ .Values.proxy.https }}"
+            {{- end }}
+            {{- if .Values.proxy.noProxy }}
+            - name: NO_PROXY
+              value: "{{ .Values.proxy.noProxy }}"
+            {{- end }}
             - name: GF_INSTALL_PLUGINS
               value: "andrewbmchugh-flow-panel, volkovlabs-variable-panel"
             - name: GF_AUTH_ANONYMOUS_ENABLED

--- a/charts/telemetry-stack/values.yaml
+++ b/charts/telemetry-stack/values.yaml
@@ -16,5 +16,5 @@ prometheus:
     enabled: true
     storageClass: ""
     accessMode: ReadWriteOnce
-    size: 1Gi
+    size: 3Gi
     annotations: {}

--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,7 @@ echo "Installing telemetry-stack helm chart..."
 proxy_var="${https_proxy:-$HTTPS_PROXY}"
 if [[ -n "$proxy_var" ]]; then
     echo "Using proxy for grafana deployment: $proxy_var"
-    noproxy="localhost,127.0.0.1,.local,.internal,.svc"
+    noproxy="localhost\,127.0.0.1\,.local\,.internal\,.svc"
 
     helm install telemetry-stack ./charts/telemetry-stack \
     --set proxy.https="$proxy_var" \

--- a/init.sh
+++ b/init.sh
@@ -17,8 +17,22 @@ uv tool upgrade clab-connector
 
 # Install helm chart
 echo "Installing telemetry-stack helm chart..."
-helm install telemetry-stack ./charts/telemetry-stack \
-  --create-namespace -n eda-telemetry
+
+proxy_var="${https_proxy:-$HTTPS_PROXY}"
+if [[ -n "$proxy_var" ]]; then
+    echo "Using proxy for grafana deployment: $proxy_var"
+    noproxy="localhost,127.0.0.1,.local,.internal,.svc"
+
+    helm install telemetry-stack ./charts/telemetry-stack \
+    --set proxy.https="$proxy_var" \
+    --set proxy.noProxy="$noproxy" \
+    --create-namespace -n eda-telemetry
+else
+    helm install telemetry-stack ./charts/telemetry-stack \
+    --create-namespace -n eda-telemetry
+fi
+
+
 
 # Wait for alloy service to be ready and get external IP
 echo "Waiting for alloy service to get external IP..."


### PR DESCRIPTION
- Added new values to configure HTTPS proxy settings for Grafana.
- Updated init.sh to enable installation using user's the https_proxy or HTTPS_PROXY environment variables if set
- Increased Prometheus PVC size to 3Gi
- Prometheus retention size to improve storage management.