### PR TITLE
Use new clab types for ixr nodes

### DIFF
--- a/eda-st.clab.yaml
+++ b/eda-st.clab.yaml
@@ -8,7 +8,7 @@ topology:
   kinds:
     nokia_srlinux:
       image: ghcr.io/nokia/srlinux:25.3.2
-      type: ixrd2l
+      type: ixr-d2l
 
   nodes:
     leaf1:
@@ -29,10 +29,12 @@ topology:
 
     spine1:
       kind: nokia_srlinux
+      type: ixr-d3l
       mgmt-ipv4: 10.58.2.21
 
     spine2:
       kind: nokia_srlinux
+      type: ixr-d3l
       mgmt-ipv4: 10.58.2.22
 
     server1:


### PR DESCRIPTION
- Changes type of IXRs to new clab format.
- At the same time suggestion to change spines from D2L to D3L


> [!IMPORTANT]
> If considered useful, it should only be merged when clab-connector supports the new types https://github.com/eda-labs/clab-connector/issues/82