### PR TITLE
Use edactl to create eda resources in a single transaction

### DIFF
--- a/manifests/common/0050_http_proxy.yaml
+++ b/manifests/common/0050_http_proxy.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   authType: atDestination
   rootUrl: http://prometheus.eda-telemetry.svc.cluster.local:9090/
----
+# ---
 # # Alloy
 # # ${EDA_URL}/core/httpproxy/v1/alloy
 # apiVersion: core.eda.nokia.com/v1


### PR DESCRIPTION
Instead of using `kubectl apply` for each manifest separately, we push the manifests to the toolbox pod and install all resources in a single transaction.
